### PR TITLE
Code standards improvements and related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 /.php-cs-fixer.cache
+/composer.lock
+/vendor/
+/public/

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -7,3 +7,6 @@ nglasl\mediawesome\MediaPageAttribute:
 SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - 'nglasl\mediawesome\SiteConfigMediaPermissionExtension'
+nglasl\mediawesome\MediaPage:
+  extensions:
+    - 'nglasl\mediawesome\MediaPageLinkExtension'

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,17 @@
         "silverstripe/framework": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "cambis/silverstripe-rector": "^1",
+        "cambis/silverstan": "^1",
+        "phpunit/phpunit": "^9.5",
+        "nswdpc/ci-files": "dev-v-3"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/nswdpc/ci-files.git"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "nglasl\\mediawesome\\": [
@@ -41,5 +50,11 @@
         "expose": [
             "client"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,15 @@
         "silverstripe/framework": "^5"
     },
     "require-dev": {
-        "cambis/silverstripe-rector": "^1",
-        "cambis/silverstan": "^1",
+        "cambis/silverstripe-rector": "^2",
+        "cambis/silverstan": "^2",
         "phpunit/phpunit": "^9.5",
-        "nswdpc/ci-files": "dev-v-3"
+        "nswdpc/ci-files": "dev-v-4",
+        "phpstan/phpstan": "^2",
+        "rector/rector": "^2",
+        "phpstan/phpstan-phpunit": "^2",
+        "friendsofphp/php-cs-fixer": "^3"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/nswdpc/ci-files.git"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "nglasl\\mediawesome\\": [
@@ -56,5 +54,11 @@
             "composer/installers": true,
             "silverstripe/vendor-plugin": true
         }
+    },
+    "scripts": {
+        "phpstan-analyse": "./vendor/bin/phpstan analyse --ansi --no-progress --no-interaction --configuration vendor/nswdpc/ci-files/phpstan/.phpstan.silverstripe.neon src/ tests/*.php",
+        "rector-dryrun": "./vendor/bin/rector process --dry-run --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_53_83.php src/ tests/*.php",
+        "rector-process": "./vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_53_83.php src/ tests/*.php",
+        "phpcsfixer-fix": "./vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src/ tests/*.php"
     }
 }

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -68,7 +68,8 @@ class MediaHolderController extends \PageController
         // Retrieve custom request filters.
 
         $request = $this->getRequest();
-        if ($limitVar = $request->getVar('limit')) {
+        $limitVar = (int)$request->getVar('limit');
+        if($limitVar > 0) {
             $limit = ($limitVar > 100) ? 100 : $limitVar;
         }
 

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -70,7 +70,7 @@ class MediaHolderController extends \PageController
 
         $request = $this->getRequest();
         $limitVar = (int)$request->getVar('limit');
-        if($limitVar > 0) {
+        if ($limitVar > 0) {
             $limit = ($limitVar > 100) ? 100 : $limitVar;
         }
 

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -41,7 +41,7 @@ class MediaHolderController extends \PageController
         $page = $this->data();
         $type = $page->MediaType();
         $templates = [];
-        if($type->exists()) {
+        if ($type->exists()) {
             $templates[] = 'MediaHolder_' . str_replace(' ', '', $type->Title);
         }
 
@@ -68,15 +68,15 @@ class MediaHolderController extends \PageController
         // Retrieve custom request filters.
 
         $request = $this->getRequest();
-        if($limitVar = $request->getVar('limit')) {
+        if ($limitVar = $request->getVar('limit')) {
             $limit = ($limitVar > 100) ? 100 : $limitVar;
         }
 
-        if($sortVar = $request->getVar('sort')) {
+        if ($sortVar = $request->getVar('sort')) {
             $sort = $sortVar;
         }
 
-        if($orderVar = $request->getVar('order')) {
+        if ($orderVar = $request->getVar('order')) {
             $order = $orderVar;
         }
 
@@ -90,11 +90,11 @@ class MediaHolderController extends \PageController
 
         // Validate the date request filter.
 
-        if($from) {
+        if ($from) {
             $valid = true;
             $date = [];
-            foreach(explode('-', (string) $from) as $segment) {
-                if(!is_numeric($segment)) {
+            foreach (explode('-', (string) $from) as $segment) {
+                if (!is_numeric($segment)) {
                     $valid = false;
                     break;
                 } else {
@@ -102,11 +102,11 @@ class MediaHolderController extends \PageController
                 }
             }
 
-            if($valid) {
+            if ($valid) {
 
                 // This is used to determine the direction to filter, so it makes sense from a user's perspective.
 
-                if($order === 'DESC') {
+                if ($order === 'DESC') {
                     $date[count($date) - 1]++;
                     $direction = '<';
                 } else {
@@ -135,7 +135,7 @@ class MediaHolderController extends \PageController
 
         // Merge both category and tag result sets.
 
-        if($category && $tag) {
+        if ($category && $tag) {
             $intersection = array_uintersect($categoryChildren->toArray(), $tagChildren->toArray(), fn ($first, $second): int|float => $first->ID - $second->ID);
             $children = ArrayList::create($intersection);
         }
@@ -187,26 +187,26 @@ class MediaHolderController extends \PageController
 
         // Determine whether a controller action resolves.
 
-        if($this->hasAction($URL) && $this->checkAccessAction($URL)) {
+        if ($this->hasAction($URL) && $this->checkAccessAction($URL)) {
             $output = $this->$URL($request);
 
             // The current request URL has been successfully parsed.
 
-            while(!$request->allParsed()) {
+            while (!$request->allParsed()) {
                 $request->shift();
             }
 
             return $output;
-        } elseif(!is_numeric($URL)) {
+        } elseif (!is_numeric($URL)) {
 
             // Determine whether a media page child once existed, and redirect appropriately.
 
             $response = $this->resolveURL();
-            if($response instanceof \SilverStripe\Control\HTTPResponse) {
+            if ($response instanceof \SilverStripe\Control\HTTPResponse) {
 
                 // The current request URL has been successfully parsed.
 
-                while(!$request->allParsed()) {
+                while (!$request->allParsed()) {
                     $request->shift();
                 }
 
@@ -225,7 +225,7 @@ class MediaHolderController extends \PageController
             $URL
         ];
         $remaining = $request->remaining();
-        if($remaining) {
+        if ($remaining) {
             $remaining = explode('/', $remaining);
 
             // Determine the media page child to display.
@@ -236,16 +236,16 @@ class MediaHolderController extends \PageController
             // Iterate the formatted URL segments.
 
             $iteration = 1;
-            foreach($remaining as $segment) {
+            foreach ($remaining as $segment) {
                 $request->shift();
-                if($child) {
+                if ($child) {
 
                     // Determine whether a controller action has been defined.
 
                     $action = $segment;
                     break;
-                } elseif(!is_numeric($segment)) {
-                    if($iteration === 4) {
+                } elseif (!is_numeric($segment)) {
+                    if ($iteration === 4) {
 
                         // The remaining URL doesn't match the month/day/media format.
 
@@ -259,7 +259,7 @@ class MediaHolderController extends \PageController
                         'URLSegment' => $segment
                     ]);
                     $date = [];
-                    foreach($segments as $previous) {
+                    foreach ($segments as $previous) {
                         $date[] = str_pad($previous, 2, '0', STR_PAD_LEFT);
                     }
 
@@ -271,13 +271,13 @@ class MediaHolderController extends \PageController
 
                     // Determine whether a media page child once existed, and redirect appropriately.
 
-                    if(is_null($child)) {
+                    if (is_null($child)) {
                         $response = $this->resolveURL();
-                        if($response instanceof \SilverStripe\Control\HTTPResponse) {
+                        if ($response instanceof \SilverStripe\Control\HTTPResponse) {
 
                             // The current request URL has been successfully parsed.
 
-                            while(!$request->allParsed()) {
+                            while (!$request->allParsed()) {
                                 $request->shift();
                             }
 
@@ -297,19 +297,19 @@ class MediaHolderController extends \PageController
 
             // Retrieve the media page child controller, and determine whether an action resolves.
 
-            if($child) {
+            if ($child) {
                 $controller = ModelAsController::controller_for($child);
 
                 // Determine whether a controller action resolves.
 
-                if(is_null($action)) {
+                if (is_null($action)) {
                     return $controller;
-                } elseif($controller->hasAction($action) && $controller->checkAccessAction($action)) {
+                } elseif ($controller->hasAction($action) && $controller->checkAccessAction($action)) {
                     $output = $controller->$action($request);
 
                     // The current request URL has been successfully parsed.
 
-                    while(!$request->allParsed()) {
+                    while (!$request->allParsed()) {
                         $request->shift();
                     }
 
@@ -332,7 +332,7 @@ class MediaHolderController extends \PageController
 
         // The new request URL doesn't require parsing.
 
-        while(!$newRequest->allParsed()) {
+        while (!$newRequest->allParsed()) {
             $newRequest->shift();
         }
 
@@ -365,7 +365,7 @@ class MediaHolderController extends \PageController
 
         // Make sure the current request URL doesn't match the resolution.
 
-        if($resolution && ($page !== substr($comparison, strrpos($comparison, '/') + 1))) {
+        if ($resolution && ($page !== substr($comparison, strrpos($comparison, '/') + 1))) {
 
             // Retrieve the current request parameters.
 
@@ -427,7 +427,7 @@ class MediaHolderController extends \PageController
         // Remove validation if clear has been triggered.
 
         $request = $this->getRequest();
-        if($request->getVar('action_clearFilters')) {
+        if ($request->getVar('action_clearFilters')) {
             $form->unsetValidator();
         }
 
@@ -454,7 +454,7 @@ class MediaHolderController extends \PageController
         $from = $request->getVar('from');
         $link = $this->Link();
         $separator = '?';
-        if($from) {
+        if ($from) {
 
             // Determine the formatted URL to represent the request filter.
 
@@ -466,12 +466,12 @@ class MediaHolderController extends \PageController
 
         $category = $request->getVar('category');
         $tag = $request->getVar('tag');
-        if($category) {
+        if ($category) {
             $link = HTTP::setGetVar('category', $category, $link, $separator);
             $separator = '&';
         }
 
-        if($tag) {
+        if ($tag) {
             $link = HTTP::setGetVar('tag', $tag, $link, $separator);
         }
 

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -19,8 +19,8 @@ use SilverStripe\ORM\PaginatedList;
 
 /**
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @extends \PageController<\nglasl\mediawesome\MediaHolder>
  */
-
 class MediaHolderController extends \PageController
 {
     private static array $allowed_actions = [

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -3,6 +3,7 @@
 namespace nglasl\mediawesome;
 
 use SilverStripe\CMS\Controllers\ModelAsController;
+use SilverStripe\CMS\Controllers\OldPageRedirector;
 use SilverStripe\Control\HTTP;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -358,7 +359,7 @@ class MediaHolderController extends \PageController
 
         // Determine whether a media page child once existed.
 
-        $resolution = self::find_old_page([
+        $resolution = OldPageRedirector::find_old_page([
             $holder,
             $page
         ]);

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -6,7 +6,6 @@ use SilverStripe\CMS\Controllers\ModelAsController;
 use SilverStripe\CMS\Controllers\OldPageRedirector;
 use SilverStripe\Control\HTTP;
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\DateField;
 use SilverStripe\Forms\FieldList;

--- a/src/controllers/MediaHolderController.php
+++ b/src/controllers/MediaHolderController.php
@@ -138,7 +138,7 @@ class MediaHolderController extends \PageController
         // Merge both category and tag result sets.
 
         if ($category && $tag) {
-            $intersection = array_uintersect($categoryChildren->toArray(), $tagChildren->toArray(), fn ($first, $second): int|float => $first->ID - $second->ID);
+            $intersection = array_uintersect($categoryChildren->toArray(), $tagChildren->toArray(), fn ($first, $second): int => $first->ID - $second->ID);
             $children = ArrayList::create($intersection);
         }
 

--- a/src/controllers/MediaPageController.php
+++ b/src/controllers/MediaPageController.php
@@ -25,7 +25,7 @@ class MediaPageController extends \PageController
         // Use a custom media type page template if one exists.
         $type = $page->MediaType();
         $templates = [];
-        if($type->exists()) {
+        if ($type->exists()) {
             $templates[] = 'MediaPage_' . str_replace(' ', '', $type->Title);
         }
 

--- a/src/controllers/MediaPageController.php
+++ b/src/controllers/MediaPageController.php
@@ -4,8 +4,8 @@ namespace nglasl\mediawesome;
 
 /**
  *  @author Nathan Glasl <nathan@symbiote.com.au>
+ * @extends \PageController<\nglasl\mediawesome\MediaPage>
  */
-
 class MediaPageController extends \PageController
 {
     /**

--- a/src/extensions/MediaPageLinkExtension.php
+++ b/src/extensions/MediaPageLinkExtension.php
@@ -10,10 +10,11 @@ use SilverStripe\Core\Extension;
  */
 class MediaPageLinkExtension extends Extension
 {
-    public function updateRelativeLink(string &$link, ?string $base = null, ?string $action = null) {
+    public function updateRelativeLink(string &$link, ?string $base = null, ?string $action = null)
+    {
         $mediaPage = $this->getOwner();
         $urlFormattingPrefix = $mediaPage->getUrlFormattingPrefix();
-        if($urlFormattingPrefix !== '') {
+        if ($urlFormattingPrefix !== '') {
             $parts = explode("/", $link);
             $last = array_pop($parts);
             $parts[] = $urlFormattingPrefix;

--- a/src/extensions/MediaPageLinkExtension.php
+++ b/src/extensions/MediaPageLinkExtension.php
@@ -6,7 +6,6 @@ use SilverStripe\Core\Extension;
 
 /**
  * Provide link handling for nglasl\mediawesome\MediaPage
- * @extends \SilverStripe\ORM\Extension
  * @extends \SilverStripe\Core\Extension<(\nglasl\mediawesome\MediaPage & static)>
  */
 class MediaPageLinkExtension extends Extension

--- a/src/extensions/MediaPageLinkExtension.php
+++ b/src/extensions/MediaPageLinkExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace nglasl\mediawesome;
+
+use SilverStripe\Core\Extension;
+
+/**
+ * Provide link handling for nglasl\mediawesome\MediaPage
+ * @extends \SilverStripe\ORM\Extension
+ */
+class MediaPageLinkExtension extends Extension
+{
+    public function updateRelativeLink(string &$link, ?string $base = null, ?string $action = null) {
+        $mediaPage = $this->getOwner();
+        $urlFormattingPrefix = $mediaPage->getUrlFormattingPrefix();
+        if($urlFormattingPrefix !== '') {
+            $parts = explode("/", $link);
+            $last = array_pop($parts);
+            $parts[] = $urlFormattingPrefix;
+            $parts[] = $last;
+            $link = implode("/", $parts);
+        }
+
+    }
+
+}

--- a/src/extensions/MediaPageLinkExtension.php
+++ b/src/extensions/MediaPageLinkExtension.php
@@ -7,6 +7,7 @@ use SilverStripe\Core\Extension;
 /**
  * Provide link handling for nglasl\mediawesome\MediaPage
  * @extends \SilverStripe\ORM\Extension
+ * @extends \SilverStripe\Core\Extension<(\nglasl\mediawesome\MediaPage & static)>
  */
 class MediaPageLinkExtension extends Extension
 {

--- a/src/extensions/SiteConfigMediaPermissionExtension.php
+++ b/src/extensions/SiteConfigMediaPermissionExtension.php
@@ -11,8 +11,9 @@ use SilverStripe\Security\Permission;
 /**
  *	This allows permission configuration for customisation of media.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @property ?string $MediaPermission
+ * @extends \SilverStripe\ORM\DataExtension<(\SilverStripe\SiteConfig\SiteConfig & static)>
  */
-
 class SiteConfigMediaPermissionExtension extends DataExtension
 {
     /**
@@ -27,6 +28,7 @@ class SiteConfigMediaPermissionExtension extends DataExtension
      *	Allow permission configuration for customisation of media.
      */
 
+    #[\Override]
     public function updateCMSFields(FieldList $fields)
     {
 

--- a/src/extensions/SiteConfigMediaPermissionExtension.php
+++ b/src/extensions/SiteConfigMediaPermissionExtension.php
@@ -37,7 +37,7 @@ class SiteConfigMediaPermissionExtension extends DataExtension
 
         // Confirm that the current CMS user has permission.
 
-        if(Permission::check('EDIT_SITECONFIG') === false) {
+        if (Permission::check('EDIT_SITECONFIG') === false) {
             $fields->addFieldToTab('Root.Access', $options = ReadonlyField::create(
                 'Media',
                 'Who can customise media?',

--- a/src/objects/MediaAttribute.php
+++ b/src/objects/MediaAttribute.php
@@ -10,8 +10,12 @@ use SilverStripe\Versioned\Versioned;
 /**
  *	This is a CMS attribute for a media type.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @property string $Title
+ * @property ?string $OriginalTitle
+ * @property int $MediaTypeID
+ * @method \nglasl\mediawesome\MediaType MediaType()
+ * @method \SilverStripe\ORM\ManyManyList<\nglasl\mediawesome\MediaPage> MediaPages()
  */
-
 class MediaAttribute extends DataObject
 {
     private static string $table_name = 'MediaAttribute';
@@ -29,24 +33,28 @@ class MediaAttribute extends DataObject
         'MediaPages' => MediaPage::class . '.MediaAttributes'
     ];
 
+    #[\Override]
     public function canView($member = null)
     {
 
         return true;
     }
 
+    #[\Override]
     public function canEdit($member = null)
     {
 
         return $this->checkPermissions($member);
     }
 
+    #[\Override]
     public function canCreate($member = null, $context = [])
     {
 
         return $this->checkPermissions($member);
     }
 
+    #[\Override]
     public function canDelete($member = null)
     {
 
@@ -85,6 +93,7 @@ class MediaAttribute extends DataObject
         return Permission::check($configuration->MediaPermission, 'any', $member);
     }
 
+    #[\Override]
     public function getCMSFields()
     {
 
@@ -103,6 +112,7 @@ class MediaAttribute extends DataObject
      *	Confirm that the current attribute is valid.
      */
 
+    #[\Override]
     public function validate()
     {
 
@@ -120,6 +130,7 @@ class MediaAttribute extends DataObject
         return $result;
     }
 
+    #[\Override]
     public function onBeforeWrite()
     {
 
@@ -132,6 +143,7 @@ class MediaAttribute extends DataObject
         }
     }
 
+    #[\Override]
     public function onAfterWrite()
     {
 
@@ -144,6 +156,7 @@ class MediaAttribute extends DataObject
         }
     }
 
+    #[\Override]
     public function onAfterDelete()
     {
 

--- a/src/objects/MediaAttribute.php
+++ b/src/objects/MediaAttribute.php
@@ -75,7 +75,7 @@ class MediaAttribute extends DataObject
         $typeDefaults = MediaPage::config()->get('type_defaults');
         $mediaType = $this->MediaType();
         $title = $mediaType && $mediaType->isInDB() ? trim($mediaType->Title ?? '') : '';
-        if($title !== '') {
+        if ($title !== '') {
             return !isset($typeDefaults[$title]) || !in_array($this->OriginalTitle, $typeDefaults[$title]);
         } else {
             return false;

--- a/src/objects/MediaAttribute.php
+++ b/src/objects/MediaAttribute.php
@@ -53,9 +53,9 @@ class MediaAttribute extends DataObject
         // Determine whether this is being used.
 
         $current = Versioned::get_stage();
-        foreach(singleton(Versioned::class)->getVersionedStages() as $stage) {
+        foreach (singleton(Versioned::class)->getVersionedStages() as $stage) {
             Versioned::set_stage($stage);
-            if($this->MediaPages()->exists() && $this->MediaPages()->where('MediaPageAttribute.Content IS NOT NULL')->exists()) {
+            if ($this->MediaPages()->exists() && $this->MediaPages()->where('MediaPageAttribute.Content IS NOT NULL')->exists()) {
                 return false;
             }
         }
@@ -110,7 +110,7 @@ class MediaAttribute extends DataObject
 
         // Confirm that the current attribute has been given a title.
 
-        if($result->isValid() && !$this->Title) {
+        if ($result->isValid() && !$this->Title) {
             $result->addError('"Title" required!');
         }
 
@@ -127,7 +127,7 @@ class MediaAttribute extends DataObject
 
         // Set the original title of the current attribute for use in templates.
 
-        if(!$this->OriginalTitle) {
+        if (!$this->OriginalTitle) {
             $this->OriginalTitle = $this->Title;
         }
     }
@@ -139,7 +139,7 @@ class MediaAttribute extends DataObject
 
         // This needs to appear on media pages of the respective type.
 
-        foreach(MediaPage::get()->filter('MediaTypeID', $this->MediaTypeID) as $page) {
+        foreach (MediaPage::get()->filter('MediaTypeID', $this->MediaTypeID) as $page) {
             $page->MediaAttributes()->add($this);
         }
     }
@@ -152,7 +152,7 @@ class MediaAttribute extends DataObject
         // Clean up the pages associated with this.
 
         $current = Versioned::get_stage();
-        foreach(singleton(Versioned::class)->getVersionedStages() as $stage) {
+        foreach (singleton(Versioned::class)->getVersionedStages() as $stage) {
             Versioned::set_stage($stage);
             MediaPageAttribute::get()->filter('MediaAttributeID', $this->ID)->removeAll();
         }

--- a/src/objects/MediaAttribute.php
+++ b/src/objects/MediaAttribute.php
@@ -72,9 +72,14 @@ class MediaAttribute extends DataObject
 
         // Determine whether this is user created.
 
-        $config = MediaPage::config();
-        $type = $this->MediaType()->Title;
-        return !isset($config->type_defaults[$type]) || !in_array($this->OriginalTitle, $config->type_defaults[$type]);
+        $typeDefaults = MediaPage::config()->get('type_defaults');
+        $mediaType = $this->MediaType();
+        $title = $mediaType && $mediaType->isInDB() ? trim($mediaType->Title ?? '') : '';
+        if($title !== '') {
+            return !isset($typeDefaults[$title]) || !in_array($this->OriginalTitle, $typeDefaults[$title]);
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/objects/MediaAttribute.php
+++ b/src/objects/MediaAttribute.php
@@ -184,7 +184,7 @@ class MediaAttribute extends DataObject
     public function getTemplateClass(): string
     {
 
-        return strtolower($this->OriginalTitle);
+        return strtolower((string) $this->OriginalTitle);
     }
 
 }

--- a/src/objects/MediaPageAttribute.php
+++ b/src/objects/MediaPageAttribute.php
@@ -50,7 +50,7 @@ class MediaPageAttribute extends DataObject
 
         // Determine the field type.
 
-        if(strrpos($this->getTitle(), 'Date')) {
+        if (strrpos($this->getTitle(), 'Date')) {
 
             // The user expects this to be a date attribute.
 

--- a/src/objects/MediaPageAttribute.php
+++ b/src/objects/MediaPageAttribute.php
@@ -9,8 +9,13 @@ use SilverStripe\ORM\DataObject;
 /**
  *	This is essentially the versioned join between `MediaPage` and `MediaAttribute`, since each page will have different content for an attribute.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @property ?string $Content
+ * @property int $MediaPageID
+ * @property int $MediaAttributeID
+ * @method \nglasl\mediawesome\MediaPage MediaPage()
+ * @method \nglasl\mediawesome\MediaAttribute MediaAttribute()
+ * @mixin \SilverStripe\Versioned\Versioned
  */
-
 class MediaPageAttribute extends DataObject
 {
     private static string $table_name = 'MediaPageAttribute';
@@ -29,18 +34,21 @@ class MediaPageAttribute extends DataObject
         'Content'
     ];
 
+    #[\Override]
     public function canDelete($member = null)
     {
 
         return false;
     }
 
+    #[\Override]
     public function getTitle()
     {
 
         return $this->MediaAttribute()->Title;
     }
 
+    #[\Override]
     public function getCMSFields()
     {
 

--- a/src/objects/MediaPageAttribute.php
+++ b/src/objects/MediaPageAttribute.php
@@ -44,8 +44,8 @@ class MediaPageAttribute extends DataObject
     #[\Override]
     public function getTitle()
     {
-
-        return $this->MediaAttribute()->Title;
+        $mediaAttribute = $this->MediaAttribute();
+        return $mediaAttribute && $mediaAttribute->isInDB() ? $mediaAttribute->Title : null;
     }
 
     #[\Override]

--- a/src/objects/MediaTag.php
+++ b/src/objects/MediaTag.php
@@ -54,9 +54,9 @@ class MediaTag extends DataObject
 
         // Confirm that the current tag has been given a title and doesn't already exist.
 
-        if($result->isValid() && !$this->Title) {
+        if ($result->isValid() && !$this->Title) {
             $result->addError('"Title" required!');
-        } elseif($result->isValid() && MediaTag::get_one(MediaTag::class, [
+        } elseif ($result->isValid() && MediaTag::get_one(MediaTag::class, [
             'ID != ?' => $this->ID,
             'Title = ?' => $this->Title
         ])) {

--- a/src/objects/MediaTag.php
+++ b/src/objects/MediaTag.php
@@ -7,8 +7,8 @@ use SilverStripe\ORM\DataObject;
 /**
  *	This is a CMS tag for a media page.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @property string $Title
  */
-
 class MediaTag extends DataObject
 {
     private static string $table_name = 'MediaTag';
@@ -19,24 +19,28 @@ class MediaTag extends DataObject
 
     private static string $default_sort = 'Title';
 
+    #[\Override]
     public function canView($member = null)
     {
 
         return true;
     }
 
+    #[\Override]
     public function canEdit($member = null)
     {
 
         return true;
     }
 
+    #[\Override]
     public function canCreate($member = null, $context = [])
     {
 
         return true;
     }
 
+    #[\Override]
     public function canDelete($member = null)
     {
 
@@ -47,6 +51,7 @@ class MediaTag extends DataObject
      *	Confirm that the current tag is valid.
      */
 
+    #[\Override]
     public function validate()
     {
 

--- a/src/objects/MediaType.php
+++ b/src/objects/MediaType.php
@@ -78,7 +78,7 @@ class MediaType extends DataObject
     {
 
         $fields = parent::getCMSFields();
-        if($this->Title) {
+        if ($this->Title) {
 
             // Display the title as read only.
 
@@ -115,9 +115,9 @@ class MediaType extends DataObject
 
         // Confirm that the current type has been given a title and doesn't already exist.
 
-        if($result->isValid() && !$this->Title) {
+        if ($result->isValid() && !$this->Title) {
             $result->addError('"Title" required!');
-        } elseif($result->isValid() && MediaType::get_one(MediaType::class, [
+        } elseif ($result->isValid() && MediaType::get_one(MediaType::class, [
             'ID != ?' => $this->ID,
             'Title = ?' => $this->Title
         ])) {

--- a/src/objects/MediaType.php
+++ b/src/objects/MediaType.php
@@ -137,4 +137,11 @@ class MediaType extends DataObject
         return $result;
     }
 
+    #[\Override]
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+        $this->Title = strip_tags($this->Title ?? '');
+    }
+
 }

--- a/src/objects/MediaType.php
+++ b/src/objects/MediaType.php
@@ -13,8 +13,9 @@ use SilverStripe\SiteConfig\SiteConfig;
 /**
  *	This is a CMS type/category of media.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @property string $Title
+ * @method \SilverStripe\ORM\HasManyList<\nglasl\mediawesome\MediaAttribute> MediaAttributes()
  */
-
 class MediaType extends DataObject
 {
     private static string $table_name = 'MediaType';
@@ -29,24 +30,28 @@ class MediaType extends DataObject
 
     private static string $default_sort = 'Title';
 
+    #[\Override]
     public function canView($member = null)
     {
 
         return true;
     }
 
+    #[\Override]
     public function canEdit($member = null)
     {
 
         return true;
     }
 
+    #[\Override]
     public function canCreate($member = null, $context = [])
     {
 
         return $this->checkPermissions($member);
     }
 
+    #[\Override]
     public function canDelete($member = null)
     {
 
@@ -74,6 +79,7 @@ class MediaType extends DataObject
         return Permission::check($configuration->MediaPermission, 'any', $member);
     }
 
+    #[\Override]
     public function getCMSFields()
     {
 
@@ -108,6 +114,7 @@ class MediaType extends DataObject
      *	Confirm that the current type is valid.
      */
 
+    #[\Override]
     public function validate()
     {
 

--- a/src/objects/MediaType.php
+++ b/src/objects/MediaType.php
@@ -60,7 +60,7 @@ class MediaType extends DataObject
         $config = MediaPage::config();
         return
             !MediaHolder::get()->filter('MediaTypeID', $this->ID)->exists()
-            && !isset($config->type_defaults[$this->Title]);
+            && !isset($config->get('type_defaults')[$this->Title]);
     }
 
     /**

--- a/src/pages/MediaHolder.php
+++ b/src/pages/MediaHolder.php
@@ -107,7 +107,7 @@ class MediaHolder extends \Page
 
         // Apply the first media type by default.
 
-        if(!$this->MediaTypeID) {
+        if (!$this->MediaTypeID) {
             $existing = MediaType::get()->first();
             $this->MediaTypeID = $existing->ID;
         }

--- a/src/pages/MediaHolder.php
+++ b/src/pages/MediaHolder.php
@@ -12,8 +12,10 @@ use SilverStripe\ORM\DataList;
 /**
  *	Displays media holder/page children, with optional date/tag filters.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
+ * @property ?string $URLFormatting
+ * @property int $MediaTypeID
+ * @method \nglasl\mediawesome\MediaType MediaType()
  */
-
 class MediaHolder extends \Page
 {
     private static string $table_name = 'MediaHolder';
@@ -37,6 +39,7 @@ class MediaHolder extends \Page
 
     private static string $icon = 'nglasl/silverstripe-mediawesome: client/images/holder.png';
 
+    #[\Override]
     public function getCMSFields()
     {
 
@@ -100,6 +103,7 @@ class MediaHolder extends \Page
         return $fields;
     }
 
+    #[\Override]
     public function onBeforeWrite()
     {
 

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -485,9 +485,9 @@ class MediaPage extends \Page
     #[\Override]
     public function Link($action = null)
     {
-        $externaLink = $this->getExternalLink();
-        if ($externaLink !== '') {
-            return $externaLink;
+        $externalLink = $this->getExternalLink();
+        if ($externalLink !== '') {
+            return $externalLink;
         } else {
             // call parent::Link, which itself calls RelativeLink()
             return parent::Link($action);
@@ -500,9 +500,9 @@ class MediaPage extends \Page
     #[\Override]
     public function AbsoluteLink($action = null)
     {
-        $externaLink = $this->getExternalLink();
-        if ($externaLink !== '') {
-            return $externaLink;
+        $externalLink = $this->getExternalLink();
+        if ($externalLink !== '') {
+            return $externalLink;
         } else {
             return parent::AbsoluteLink($action);
         }

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -96,11 +96,11 @@ class MediaPage extends \Page
 
         // Determine whether this requires an SS3 to SS4 migration.
 
-        if(MediaAttribute::get()->filter('MediaTypeID', 0)->exists()) {
+        if (MediaAttribute::get()->filter('MediaTypeID', 0)->exists()) {
 
             // The problem is that class name mapping happens after this, but we need it right now to query pages.
 
-            foreach([
+            foreach ([
                 'SiteTree',
                 'SiteTree_Live',
                 'SiteTree_Versions'
@@ -126,7 +126,7 @@ class MediaPage extends \Page
                 ['LinkID' => 'ASC']
             );
             $attributes = $attributes->execute();
-            if($attributes) {
+            if ($attributes) {
 
                 // With the results from above, delete these to prevent data integrity issues.
 
@@ -138,16 +138,16 @@ class MediaPage extends \Page
 
                 // Migrate the existing media attributes.
 
-                foreach($attributes as $existing) {
+                foreach ($attributes as $existing) {
                     $page = MediaPage::get()->byID($existing['MediaPageID']);
-                    if(!$page) {
+                    if (!$page) {
 
                         // This page may no longer exist.
 
                         continue;
                     }
 
-                    if($existing['LinkID'] == -1) {
+                    if ($existing['LinkID'] == -1) {
 
                         // Instantiate a new attribute for each "master" attribute.
 
@@ -171,7 +171,7 @@ class MediaPage extends \Page
 
                     // The attributes are versioned, but should only be published when it's considered safe to do so.
 
-                    if($page->isPublished() && !$page->isModifiedOnDraft()) {
+                    if ($page->isPublished() && !$page->isModifiedOnDraft()) {
                         $page->publishRecursive();
                     }
                 }
@@ -184,7 +184,7 @@ class MediaPage extends \Page
             'MediaType.Title' => 'Event',
             'OriginalTitle' => 'Start Time'
         ]);
-        foreach($attributes as $attribute) {
+        foreach ($attributes as $attribute) {
 
             // These should now be "time" attributes.
 
@@ -195,26 +195,26 @@ class MediaPage extends \Page
 
         // Instantiate the default media types and their respective attributes.
 
-        foreach($this->config()->type_defaults as $name => $attributes) {
+        foreach ($this->config()->type_defaults as $name => $attributes) {
 
             // Confirm that the media type doesn't already exist before creating it.
 
             $type = MediaType::get()->filter([
                 'Title' => $name
             ])->first();
-            if(!$type) {
+            if (!$type) {
                 $type = MediaType::create();
                 $type->Title = $name;
                 $type->write();
                 DB::alteration_message("\"{$name}\" Media Type", 'created');
             }
 
-            if(is_array($attributes)) {
-                foreach($attributes as $attribute) {
+            if (is_array($attributes)) {
+                foreach ($attributes as $attribute) {
 
                     // Confirm that the media attributes don't already exist before creating them.
 
-                    if(!MediaAttribute::get()->filter([
+                    if (!MediaAttribute::get()->filter([
                         'MediaTypeID' => $type->ID,
                         'OriginalTitle' => $attribute
                     ])->first()) {
@@ -245,7 +245,7 @@ class MediaPage extends \Page
         // Display a notification that the parent holder contains mixed children.
         /** @var MediaHolder $parent **/
         $parent = $this->getParent();
-        if($parent && $parent->getMediaHolderChildren()->exists()) {
+        if ($parent && $parent->getMediaHolderChildren()->exists()) {
             Requirements::css('nglasl/silverstripe-mediawesome: client/css/mediawesome.css');
             $fields->addFieldToTab('Root.Main', LiteralField::create(
                 'MediaNotification',
@@ -276,7 +276,7 @@ class MediaPage extends \Page
             'Tags',
             $tags
         ));
-        if(!$tags) {
+        if (!$tags) {
             $categoriesList->setAttribute('disabled', 'true');
             $tagsList->setAttribute('disabled', 'true');
         }
@@ -331,13 +331,13 @@ class MediaPage extends \Page
 
         // The URL segment will conflict with a year/month/day/media format when numeric.
 
-        if(is_numeric($this->URLSegment) || !($parent instanceof MediaHolder) || ($this->MediaTypeID && ($parent->MediaTypeID != $this->MediaTypeID))) {
+        if (is_numeric($this->URLSegment) || !($parent instanceof MediaHolder) || ($this->MediaTypeID && ($parent->MediaTypeID != $this->MediaTypeID))) {
 
             // Customise a validation error message.
 
-            if(is_numeric($this->URLSegment)) {
+            if (is_numeric($this->URLSegment)) {
                 $message = '"URL Segment" must not be numeric!';
-            } elseif(!($parent instanceof MediaHolder)) {
+            } elseif (!($parent instanceof MediaHolder)) {
                 $message = 'The parent needs to be a published media holder!';
             } else {
                 $message = "The media holder type doesn't match this!";
@@ -362,13 +362,13 @@ class MediaPage extends \Page
 
         // Set the default media page date.
 
-        if(!$this->Date) {
+        if (!$this->Date) {
             $this->Date = date('Y-m-d');
         }
 
         // Confirm that the external link exists.
 
-        if($this->ExternalLink) {
+        if ($this->ExternalLink) {
             // The following code was taken from RedirectorPage::onBeforeWrite()
             // on SilverStripe 4.1.1
             if ($this->ExternalLink &&
@@ -392,7 +392,7 @@ class MediaPage extends \Page
             }
 
             $file_headers = @get_headers($this->ExternalLink);
-            if($file_headers === [] || $file_headers === false || strripos((string) $file_headers[0], '404 Not Found')) {
+            if ($file_headers === [] || $file_headers === false || strripos((string) $file_headers[0], '404 Not Found')) {
                 $this->ExternalLink = null;
             }
         }
@@ -400,9 +400,9 @@ class MediaPage extends \Page
         // Apply the parent holder media type.
         /** @var MediaHolder $parent **/
         $parent = $this->getParent();
-        if($parent) {
+        if ($parent) {
             $type = $parent->MediaType();
-            if($type->exists()) {
+            if ($type->exists()) {
                 $this->MediaTypeID = $type->ID;
             }
         }
@@ -415,11 +415,11 @@ class MediaPage extends \Page
 
         // This triggers for both a save and publish, causing duplicate attributes to appear.
 
-        if(Versioned::get_stage() === 'Stage') {
+        if (Versioned::get_stage() === 'Stage') {
 
             // The attributes of the respective type need to appear on this page.
 
-            foreach($this->MediaType()->MediaAttributes() as $attribute) {
+            foreach ($this->MediaType()->MediaAttributes() as $attribute) {
                 $this->MediaAttributes()->add($attribute);
             }
         }
@@ -431,12 +431,12 @@ class MediaPage extends \Page
 
     public function Link($action = null)
     {
-        if($this->ExternalLink) {
+        if ($this->ExternalLink) {
             return $this->ExternalLink;
         }
 
         $parent = $this->getParent();
-        if(!$parent) {
+        if (!$parent) {
             return '';
         }
 
@@ -445,7 +445,7 @@ class MediaPage extends \Page
             $parent->Link(),
             "{$date}{$this->URLSegment}/"
         ];
-        if($action && is_string($action)) {
+        if ($action && is_string($action)) {
             $join[] = "{$action}/";
         }
 
@@ -458,18 +458,18 @@ class MediaPage extends \Page
 
     public function AbsoluteLink($action = null)
     {
-        if($this->ExternalLink) {
+        if ($this->ExternalLink) {
             return $this->ExternalLink;
         }
 
         $parent = $this->getParent();
-        if(!$parent) {
+        if (!$parent) {
             return '';
         }
 
         $date = ($parent->URLFormatting !== '-') ? $this->dbObject('Date')->Format($parent->URLFormatting ?: 'y/MM/dd/') : '';
         $link = $parent->AbsoluteLink() . "{$date}{$this->URLSegment}/";
-        if($action && is_string($action)) {
+        if ($action && is_string($action)) {
             $link .= "{$action}/";
         }
 

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -28,7 +28,7 @@ use SilverStripe\View\Requirements;
 /**
  *  Displays customised media content relating to the respective media type.
  *  @author Nathan Glasl <nathan@symbiote.com.au>
- * @property ?string $ExternalLink
+ * @property string $ExternalLink
  * @property ?string $Abstract
  * @property ?string $Date
  * @property int $MediaTypeID
@@ -38,6 +38,7 @@ use SilverStripe\View\Requirements;
  * @method \SilverStripe\ORM\ManyManyList<\SilverStripe\Assets\File> Attachments()
  * @method \SilverStripe\ORM\ManyManyList<\nglasl\mediawesome\MediaTag> Categories()
  * @method \SilverStripe\ORM\ManyManyList<\nglasl\mediawesome\MediaTag> Tags()
+ * @mixin \nglasl\mediawesome\MediaPageLinkExtension
  */
 class MediaPage extends \Page
 {

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -195,7 +195,7 @@ class MediaPage extends \Page
 
         // Instantiate the default media types and their respective attributes.
 
-        foreach ($this->config()->type_defaults as $name => $attributes) {
+        foreach (static::config()->get('type_defaults') as $name => $attributes) {
 
             // Confirm that the media type doesn't already exist before creating it.
 

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -492,7 +492,7 @@ class MediaPage extends \Page
      *  @parameter <{ATTRIBUTE}> string
      */
 
-    public function getAttribute(string $title): MediaAttribute
+    public function getAttribute(string $title): ?MediaAttribute
     {
 
         return $this->MediaAttributes()->filter('OriginalTitle', $title)->first();
@@ -504,7 +504,7 @@ class MediaPage extends \Page
      *  @parameter <{ATTRIBUTE}> string
      */
 
-    public function Attribute(string $title): MediaAttribute
+    public function Attribute(string $title): ?MediaAttribute
     {
 
         // This provides consistency when it comes to defining parameters from the template.

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -75,7 +75,7 @@ class MediaPage extends \Page
 
     private static bool $can_be_root = false;
 
-    private static string $allowed_children = 'none';
+    private static string|array $allowed_children = 'none';
 
     private static string $default_parent = MediaHolder::class;
 

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -447,7 +447,8 @@ class MediaPage extends \Page
      * Retrieve the formated prefix for the page link, based on this page's parent URLFormatting value
      * If there is no parent, or if the URLFormatting is not set, the prefix is not returned
      */
-    public function getUrlFormattingPrefix(?string $action = null): string {
+    public function getUrlFormattingPrefix(?string $action = null): string
+    {
         $parent = $this->getParent();
         if (!$parent || !$parent->isInDB()) {
             return '';
@@ -455,7 +456,7 @@ class MediaPage extends \Page
 
         // remove the trailing / from the formatting value, defined in the enum
         $format = trim(rtrim((string)$parent->URLFormatting, '/'));
-        if($format !== '-') {
+        if ($format !== '-') {
             // all current formats are date formats
             return $this->dbObject('Date')->Format($format);
         } else {
@@ -484,7 +485,7 @@ class MediaPage extends \Page
     public function Link($action = null)
     {
         $externaLink = $this->getExternalLink();
-        if($externaLink !== '') {
+        if ($externaLink !== '') {
             return $externaLink;
         } else {
             // call parent::Link, which itself calls RelativeLink()
@@ -499,7 +500,7 @@ class MediaPage extends \Page
     public function AbsoluteLink($action = null)
     {
         $externaLink = $this->getExternalLink();
-        if($externaLink !== '') {
+        if ($externaLink !== '') {
             return $externaLink;
         } else {
             return parent::AbsoluteLink($action);

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -28,8 +28,17 @@ use SilverStripe\View\Requirements;
 /**
  *  Displays customised media content relating to the respective media type.
  *  @author Nathan Glasl <nathan@symbiote.com.au>
+ * @property ?string $ExternalLink
+ * @property ?string $Abstract
+ * @property ?string $Date
+ * @property int $MediaTypeID
+ * @method \nglasl\mediawesome\MediaType MediaType()
+ * @method \SilverStripe\ORM\ManyManyThroughList<\nglasl\mediawesome\MediaPageAttribute> MediaAttributes()
+ * @method \SilverStripe\ORM\ManyManyList<\SilverStripe\Assets\Image> Images()
+ * @method \SilverStripe\ORM\ManyManyList<\SilverStripe\Assets\File> Attachments()
+ * @method \SilverStripe\ORM\ManyManyList<\nglasl\mediawesome\MediaTag> Categories()
+ * @method \SilverStripe\ORM\ManyManyList<\nglasl\mediawesome\MediaTag> Tags()
  */
-
 class MediaPage extends \Page
 {
     private static string $table_name = 'MediaPage';
@@ -89,6 +98,7 @@ class MediaPage extends \Page
 
     private static array $type_defaults = [];
 
+    #[\Override]
     public function requireDefaultRecords()
     {
 
@@ -229,6 +239,7 @@ class MediaPage extends \Page
         }
     }
 
+    #[\Override]
     public function getCMSFields()
     {
 
@@ -324,6 +335,7 @@ class MediaPage extends \Page
      *  Confirm that the current page is valid.
      */
 
+    #[\Override]
     public function validate()
     {
 
@@ -355,6 +367,7 @@ class MediaPage extends \Page
         return parent::validate();
     }
 
+    #[\Override]
     public function onBeforeWrite()
     {
 
@@ -408,6 +421,7 @@ class MediaPage extends \Page
         }
     }
 
+    #[\Override]
     public function onAfterWrite()
     {
 
@@ -429,6 +443,7 @@ class MediaPage extends \Page
      *  Determine the URL by using the media holder's defined URL format.
      */
 
+    #[\Override]
     public function Link($action = null)
     {
         if ($this->ExternalLink) {
@@ -456,6 +471,7 @@ class MediaPage extends \Page
      *  Determine the absolute URL by using the media holder's defined URL format.
      */
 
+    #[\Override]
     public function AbsoluteLink($action = null)
     {
         if ($this->ExternalLink) {

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -250,7 +250,7 @@ class MediaPage extends \Page
 
         // Display the media type as read only.
         $mediaType = $this->MediaType();
-        $mediaTypeTitle = $mediaType ? trim(($mediaType->Title ?? '')) : '';
+        $mediaTypeTitle = $mediaType ? strip_tags(trim($mediaType->Title ?? '')) : '';
         $fields->addFieldToTab('Root.Main', ReadonlyField::create(
             'Type',
             'Type',
@@ -264,7 +264,7 @@ class MediaPage extends \Page
             Requirements::css('nglasl/silverstripe-mediawesome: client/css/mediawesome.css');
             $fields->addFieldToTab('Root.Main', LiteralField::create(
                 'MediaNotification',
-                "<p class='mediawesome notification'><strong>Mixed {$mediaTypeTitle} Holder</strong></p>"
+                "<p class='mediawesome notification'><strong>Mixed " . htmlspecialchars($mediaTypeTitle) . " Holder</strong></p>"
             ), 'Type');
         }
 

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -4,7 +4,6 @@ namespace nglasl\mediawesome;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Image;
-use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\DateField;

--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -85,8 +85,11 @@ class MediaPage extends \Page
 
     private static bool $can_be_root = false;
 
-    // this value can be either a string or an array
-    // @phpstan-ignore silverstan.configurationProperty
+    /**
+     * This value can be either a string or an array
+     * @inheritdoc
+     * @phpstan-ignore silverstan.configurationProperty.invalid
+     */
     private static string|array $allowed_children = 'none';
 
     private static string $default_parent = MediaHolder::class;
@@ -388,8 +391,7 @@ class MediaPage extends \Page
         if ($this->ExternalLink) {
             // The following code was taken from RedirectorPage::onBeforeWrite()
             // on SilverStripe 4.1.1
-            if ($this->ExternalLink &&
-                !str_starts_with($this->ExternalLink, '//')) {
+            if (!str_starts_with($this->ExternalLink, '//')) {
                 $urlParts = parse_url($this->ExternalLink);
                 if ($urlParts) {
                     if (empty($urlParts['scheme'])) {


### PR DESCRIPTION
## Changes

+ Update dev requirements (0359f2dbb8fb058e4727a74cc20c46b91d34a366)
+ Run php-cs-fixer fix
+ Apply updates for issues picked up by phpstan analysis per (phpstan) prefixed commits
+ Fix: `find_old_page` now uses correct class (f0dad9d8b6583f78187b3b9c289f710e7b18f394)
+ Update and fix MediaPage link handling, taking into account external link  and url formatting settings for the page (e43f269b2a97761c7bfd70460c8542aa1bc33add)
+ Fix: allow null return (3563887d5833f68e10b3c69a22f825b8f0861973)
+ Improve limit handling (3f88b29b07dd559333a1017009d2c4aa0e936da5)
+ Pull configuration from API (62188ea4d8847726de8a1e4b5e3efe69aa03e900)
+ Avoid accessing properties on nulls by testing their existence first (1aab9b020fbf5bc0f650eba6edaf5e0065877fb4)
+ Run rector process  with updated SS5 configuration rules.